### PR TITLE
Allow Id to have arbitrary length instead of 16 byte limit, also add in POJO and Map tests

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,14 +77,17 @@ function toString(id: Uint8Array): string {
 }
 
 function fromString(idString: string): Id | undefined {
-  const id = IdInternal.create(16);
-  for (let i = 0; i < 16; i++) {
+  const id = IdInternal.create(idString.length);
+  for (let i = 0; i < idString.length; i++) {
     id[i] = idString.charCodeAt(i);
   }
   return id;
 }
 
 function toUUID(id: Uint8Array): string {
+  if (id.byteLength !== 16) {
+    throw new RangeError('UUID can only be created from buffers with 16 bytes');
+  }
   const uuidHex = bytes2hex(id);
   return [
     uuidHex.substr(0, 8),
@@ -130,9 +133,6 @@ function fromMultibase(idString: string): Id | undefined {
     return;
   }
   const buffer = codec.decode(idString);
-  if (buffer.byteLength !== 16) {
-    return;
-  }
   return IdInternal.create(buffer);
 }
 
@@ -147,9 +147,6 @@ function toBuffer(id: Uint8Array): Buffer {
  * Decodes as Buffer zero-copy
  */
 function fromBuffer(idBuffer: Buffer): Id | undefined {
-  if (idBuffer.byteLength !== 16) {
-    return;
-  }
   return IdInternal.create(
     idBuffer.buffer,
     idBuffer.byteOffset,

--- a/tests/Id.test.ts
+++ b/tests/Id.test.ts
@@ -1,0 +1,48 @@
+import Id from '@/Id';
+import * as utils from '@/utils';
+
+describe('Id', () => {
+  test('create id from buffer', () => {
+    const buffer = Buffer.from('abcefg');
+    const id = Id.create(buffer);
+    expect(id.toString()).toBe('abcefg');
+    expect(id + '').toBe('abcefg');
+    // Primitive value of Id is still Uint8Array
+    expect([...id.valueOf()]).toStrictEqual([...buffer]);
+  });
+  test('create id from id', () => {
+    const buffer = Buffer.allocUnsafe(32);
+    const id1 = Id.create(buffer);
+    const id2 = Id.create(id1);
+    expect([...id2]).toStrictEqual([...id1]);
+  });
+  test('id can be used as POJO keys', () => {
+    const buffer = Buffer.from('hello world');
+    const id = Id.create(buffer);
+    // Automatic string conversion takes place here
+    // However the strings may not look very pretty
+    // They are the raw binary string form
+    // So if you expect to read this string on the terminal
+    // Prefer to use an encoded form instead
+    const pojo = {
+      [id]: 'foo bar',
+    };
+    expect(pojo[id]).toBe('foo bar');
+    expect(pojo[id.toString()]).toBe('foo bar');
+    for (const k of Object.keys(pojo)) {
+      const idDecoded = utils.fromString(k);
+      expect(idDecoded).toBeDefined();
+      expect([...idDecoded!]).toStrictEqual([...id]);
+      break;
+    }
+  });
+  test('id can be used as Map keys', () => {
+    const buffer = Buffer.from('hello world');
+    const id = Id.create(buffer);
+    // The id is an object, so this is an object key
+    const map = new Map();
+    map.set(id, 'foo bar');
+    expect(map.get(id)).toBe('foo bar');
+    expect(map.get(id.toString())).toBeUndefined();
+  });
+});

--- a/tests/IdSortable.test.ts
+++ b/tests/IdSortable.test.ts
@@ -101,7 +101,7 @@ describe('IdSortable', () => {
       count--;
     }
   });
-  test('encoded multibase strings may be lexically sortable (base58btc)', () => {
+  test('encoded multibase strings may be lexically sortable (base32hex)', () => {
     // `base32hex` preserves sort order
     const idGen = new IdSortable();
     // This generating over 100,000 ids and checks that they maintain

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -20,6 +20,17 @@ describe('utils', () => {
     expect(utils.toUUID(bytes2)).toBe(id2);
     const bytes1_ = utils.fromUUID(uuid1);
     expect(Buffer.from(bytes1_!).equals(bytes1)).toBe(true);
+    // Cannot convert to UUID if the byte length is not 16 bytes
+    const hex3 = '01858a9e0e5c73edbde194f017ebdb3b0185';
+    const bytes3 = utils.hex2bytes(hex3);
+    expect(() => {
+      utils.toUUID(bytes3);
+    }).toThrow(RangeError);
+    const hex4 = '0185';
+    const bytes4 = utils.hex2bytes(hex4);
+    expect(() => {
+      utils.toUUID(bytes4);
+    }).toThrow(RangeError);
   });
   test('encoding and decoding bytes and bit strings', () => {
     // 128 size bit string


### PR DESCRIPTION
### Description

As discussed in https://github.com/MatrixAI/js-polykey/issues/254, we want `Id` to be usable for `NodeId` as well. In such a case, we don't actually want the 16 byte limit that we have in our `utils.ts` atm. This is only relevant to UUID. So the limit can be constraint to UUID conversions, and all other functions can operate more freely.

### Issues Fixed

* Relates to https://github.com/MatrixAI/js-polykey/issues/299
* Relates to https://github.com/MatrixAI/js-polykey/issues/254

### Tasks

1. [x] Add `16` byte check to `toUUID`, and throw `RangeError` if the `Id` is not 16 bytes
2. [x] Remove `16` byte limit from other conversion utilities like string, buffer and multibase
3. [x] Create tests for `Id.test.ts` to test Id creation byitself
4. [x] Add POJO and Map tests to show that `Id` can be used as Map keys, and POJO keys without any problems

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
