### PR TITLE
Patch for `fromMultibase` syntax error on plain string inputs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,7 +166,15 @@ function fromMultibase(idString: string): Id | undefined {
   if (codec == null) {
     return;
   }
-  const buffer = codec.decode(idString);
+  let buffer: Uint8Array;
+  try {
+    buffer = codec.decode(idString);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      return;
+    }
+    throw e;
+  }
   return IdInternal.create(buffer);
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -201,6 +201,7 @@ describe('utils', () => {
     // FromMultibase should only allow 16 byte ids
     expect(utils.fromMultibase('aAQ3')).toBeUndefined();
     expect(utils.fromMultibase('aAQ333333333333333AAAAAA')).toBeUndefined();
+    expect(utils.fromMultibase('helloworld')).toBeUndefined();
   });
   test('buffer encoding and decoding is zero copy', () => {
     const bytes = new Uint8Array([


### PR DESCRIPTION
### Description
The `fromMultibase()` utility was throwing a Syntax Error on plain string inputs, when it should instead have been returning `undefined`. The line this was coming from, `codec.decode()`, has now been warpped in a try-catch block in order to return undefined on this error, as is the expected behaviour.

### Tasks
1. [x] Add a catch handler on `codec.decode()` for Syntax Errors
2. [x] Update utils tests to cover this case

### Final checklist
* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
