### PR TITLE
Patch for fromMultibase error on non-multibase strings

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,10 +170,7 @@ function fromMultibase(idString: string): Id | undefined {
   try {
     buffer = codec.decode(idString);
   } catch (e) {
-    if (e instanceof SyntaxError) {
-      return;
-    }
-    throw e;
+    return;
   }
   return IdInternal.create(buffer);
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -201,6 +201,10 @@ describe('utils', () => {
     // FromMultibase should only allow 16 byte ids
     expect(utils.fromMultibase('aAQ3')).toBeUndefined();
     expect(utils.fromMultibase('aAQ333333333333333AAAAAA')).toBeUndefined();
+    expect(
+      utils.fromMultibase('zF4VfF3uRhSqgxTOOLONGxTRdVKauV9'),
+    ).toBeUndefined();
+    expect(utils.fromMultibase('zFxTOOSHORTx9')).toBeUndefined();
     expect(utils.fromMultibase('helloworld')).toBeUndefined();
   });
   test('buffer encoding and decoding is zero copy', () => {


### PR DESCRIPTION
### Description
The `fromMultibase()` utility was throwing an error on plain string/non-multibase inputs, when it should instead have been returning `undefined`. The line this was coming from, `codec.decode()`, has now been warpped in a try-catch block in order to return undefined on this error, as is the expected behaviour.

Previously a fix was pushed to only catch Syntax Errors, however this was insufficient and instead all errors should be caught,

### Tasks
1. [x] Modify the catch handler on `codec.decode()` to return on all errors
2. [x] Update utils tests to cover missed cases

### Final checklist
* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
